### PR TITLE
Improve portfolio modal accessibility

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -3,12 +3,14 @@
 // Mobile menu
 const menuToggleElement = document.querySelector(`#js-mobile-menu-toggle`);
 if (menuToggleElement) {
-  const menuHamburgerIcon = menuToggleElement.querySelector(`#js-hamburger-icon`);
+  const menuHamburgerIcon =
+    menuToggleElement.querySelector(`#js-hamburger-icon`);
   const xMark = menuToggleElement.querySelector(`#js-x-mark-icon`);
   const headerMenusElement = document.querySelector(`#js-header-menus`);
 
   menuToggleElement.addEventListener(`click`, (event) => {
-    const isMenuOpen = menuToggleElement.getAttribute(`aria-expanded`) === `true`;
+    const isMenuOpen =
+      menuToggleElement.getAttribute(`aria-expanded`) === `true`;
     isMenuOpen ? closeMobileMenu() : openMobileMenu();
   });
 
@@ -52,10 +54,14 @@ if (portfolioItems.length) {
       `.js-portfolio-modal-close`,
     );
 
-    const backdrop = portfolioItem.querySelector(`.js-portfolio-modal-backdrop`);
+    const backdrop = portfolioItem.querySelector(
+      `.js-portfolio-modal-backdrop`,
+    );
     const openModalButtons = Array.from(
       portfolioItem.querySelectorAll(`.js-open-modal`),
     );
+
+    let lastFocusedElement = null;
 
     // Function to initialize Flickity on a carousel
     function initializeFlickity(carouselElement) {
@@ -71,22 +77,75 @@ if (portfolioItems.length) {
       }
     }
 
-    // Modal Toggle
+    function openModal(trigger) {
+      modalElement.classList.remove(`hidden`);
+      document.body.classList.add(`overflow-hidden`);
+      backdrop.classList.remove(`hidden`);
+
+      initializeFlickity(mainCarousel);
+
+      lastFocusedElement = trigger;
+      modalElement.focus();
+      document.addEventListener(`keydown`, handleKeydown);
+    }
+
+    function closeModal() {
+      modalElement.classList.add(`hidden`);
+      document.body.classList.remove(`overflow-hidden`);
+      backdrop.classList.add(`hidden`);
+
+      document.removeEventListener(`keydown`, handleKeydown);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+      }
+    }
+
+    function handleKeydown(event) {
+      if (event.key === `Escape`) {
+        closeModal();
+      } else if (event.key === `Tab`) {
+        trapFocus(event);
+      }
+    }
+
+    function trapFocus(event) {
+      const focusableSelectors = [
+        `a[href]`,
+        `area[href]`,
+        `input:not([disabled])`,
+        `select:not([disabled])`,
+        `textarea:not([disabled])`,
+        `button:not([disabled])`,
+        `[tabindex]:not([tabindex="-1"])`,
+      ];
+      const focusableElements = modalElement.querySelectorAll(
+        focusableSelectors.join(`,`),
+      );
+      if (!focusableElements.length) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        lastElement.focus();
+        event.preventDefault();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        firstElement.focus();
+        event.preventDefault();
+      }
+    }
+
     portfolioItem.addEventListener(`click`, (event) => {
-      if (
+      if (openModalButtons.includes(event.target)) {
+        openModal(event.target);
+      } else if (
         modalCloseElement.contains(event.target) ||
-        openModalButtons.includes(event.target) ||
         event.target === backdrop
       ) {
-        modalElement.classList.toggle(`hidden`);
-        document.body.classList.toggle(`overflow-hidden`);
-
-        backdrop.classList.toggle(`hidden`);
-
-        if (!modalElement.classList.contains(`hidden`)) {
-          // Modal is now visible, initialize Flickity
-          initializeFlickity(mainCarousel);
-        }
+        closeModal();
       }
     });
   });

--- a/sections/portfolio.liquid
+++ b/sections/portfolio.liquid
@@ -31,7 +31,11 @@
 
           <!-- Dark layer (backdrop) -->
           <div class="js-portfolio-modal-backdrop fixed inset-0 z-10 hidden bg-black bg-opacity-75"></div>
-          <div class="js-portfolio-modal fixed  left-1/2 top-5 z-20 hidden max-h-[calc(100vh-2.5rem)] w-11/12 -translate-x-1/2 overflow-y-auto rounded-xl bg-white py-16 shadow-modal lg:w-3/5">
+          <div
+            class="js-portfolio-modal fixed  left-1/2 top-5 z-20 hidden max-h-[calc(100vh-2.5rem)] w-11/12 -translate-x-1/2 overflow-y-auto rounded-xl bg-white py-16 shadow-modal lg:w-3/5"
+            tabindex="-1"
+            aria-modal="true"
+          >
             {%- render './snippets/close-modal.svg.liquid' -%}
             <div class="relative mb-9 w-full">
               <button class="absolute left-1/2 top-0 z-10 w-4/5 -translate-x-1/2 -translate-y-1/2 rounded-xl bg-deepSlate py-2 text-2xl font-semibold text-softWhite">


### PR DESCRIPTION
## Summary
- make portfolio modal focusable with `tabindex="-1"` and `aria-modal="true"`
- add Escape key support and focus trapping for portfolio modals
- restore focus to the triggering element when modal closes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895d4b4c0e883248bf34c5ee93ca2c7