### PR TITLE
feat: preload font and swap display

### DIFF
--- a/assets/tailwind.css
+++ b/assets/tailwind.css
@@ -6,6 +6,8 @@
   font-weight: 100 900;
 
   font-style: normal;
+
+  font-display: swap;
 }
 
 *, ::before, ::after {

--- a/index.liquid
+++ b/index.liquid
@@ -3,6 +3,7 @@
   <head>
     <link rel="preconnect" href="https://www.googletagmanager.com">
     <link rel="preconnect" href="https://static.hotjar.com">
+    <link rel="preload" as="font" href="/assets/Montserrat-VariableFont_wght.ttf" type="font/ttf" crossorigin>
 
     <!-- Google Tag Manager -->
     <script>

--- a/tailwind.css
+++ b/tailwind.css
@@ -1,9 +1,9 @@
-
 @font-face {
   font-family: "Montserrat";
   src: url("Montserrat-VariableFont_wght.ttf") format("truetype");
   font-weight: 100 900;
   font-style: normal;
+  font-display: swap;
 }
 
 @tailwind base;


### PR DESCRIPTION
## Summary
- preload Montserrat font in HTML head
- ensure Montserrat font uses `font-display: swap` to avoid invisible text

## Testing
- `npm run build-css`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895d6d660f08324a1481f247cedb0f8