### PR TITLE
Add modal for full reviews

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -176,6 +176,90 @@ if (loadMoreButton) {
 }
 
 // Reviews
+const reviewItems = document.querySelectorAll(`.js-review-item`);
+if (reviewItems.length) {
+  reviewItems.forEach((reviewItem) => {
+    const modalElement = reviewItem.querySelector(`.js-review-modal`);
+    const modalCloseElement = modalElement.querySelector(
+      `.js-review-modal-close`,
+    );
+    const backdrop = reviewItem.querySelector(`.js-review-modal-backdrop`);
+    const openModalButton = reviewItem.querySelector(`.js-open-review-modal`);
+
+    let lastFocusedElement = null;
+
+    function openModal(trigger) {
+      modalElement.classList.remove(`hidden`);
+      document.body.classList.add(`overflow-hidden`);
+      backdrop.classList.remove(`hidden`);
+
+      lastFocusedElement = trigger;
+      modalElement.focus();
+      document.addEventListener(`keydown`, handleKeydown);
+    }
+
+    function closeModal() {
+      modalElement.classList.add(`hidden`);
+      document.body.classList.remove(`overflow-hidden`);
+      backdrop.classList.add(`hidden`);
+
+      document.removeEventListener(`keydown`, handleKeydown);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+      }
+    }
+
+    function handleKeydown(event) {
+      if (event.key === `Escape`) {
+        closeModal();
+      } else if (event.key === `Tab`) {
+        trapFocus(event);
+      }
+    }
+
+    function trapFocus(event) {
+      const focusableSelectors = [
+        `a[href]`,
+        `area[href]`,
+        `input:not([disabled])`,
+        `select:not([disabled])`,
+        `textarea:not([disabled])`,
+        `button:not([disabled])`,
+        `[tabindex]:not([tabindex="-1"])`,
+      ];
+      const focusableElements = modalElement.querySelectorAll(
+        focusableSelectors.join(`,`),
+      );
+      if (!focusableElements.length) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        lastElement.focus();
+        event.preventDefault();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        firstElement.focus();
+        event.preventDefault();
+      }
+    }
+
+    reviewItem.addEventListener(`click`, (event) => {
+      if (openModalButton && openModalButton.contains(event.target)) {
+        openModal(openModalButton);
+      } else if (
+        modalCloseElement.contains(event.target) ||
+        event.target === backdrop
+      ) {
+        closeModal();
+      }
+    });
+  });
+}
+
 const reviewsFlickity = new Flickity(
   `#js-reviews-items`,
   SETTINGS.reviewsFlickityObject,

--- a/sections/reviews.liquid
+++ b/sections/reviews.liquid
@@ -20,7 +20,7 @@
       <article
         itemscope
         itemtype="http://schema.org/Review"
-        class="relative mb-10 mr-3 mt-24 flex min-h-[600px] w-4/5  items-center rounded-xl bg-white px-11 pb-24 pt-28 md:max-w-[457px] lg:mx-14 lg:mt-32 lg:min-h-[710px] lg:px-20 lg:pt-36"
+        class="js-review-item relative mb-10 mr-3 mt-24 flex min-h-[600px] w-4/5  items-center rounded-xl bg-white px-11 pb-24 pt-28 md:max-w-[457px] lg:mx-14 lg:mt-32 lg:min-h-[710px] lg:px-20 lg:pt-36"
       >
         <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Service">
           <meta itemprop="name" content="{{- review.job_title -}}">
@@ -45,6 +45,7 @@
           >
             {{- review.review | truncate: 240 -}}
           </p>
+          <button type="button" class="js-open-review-modal font-bold underline">Read full review</button>
 
           <div class="absolute -right-3 top-full flex flex-col items-end space-y-1">
             {%- render './snippets/quotes-end.svg.liquid', classes: '' -%}
@@ -80,6 +81,19 @@
           /
           {{- reviews.size -}}
         </span>
+        <!-- Dark layer (backdrop) -->
+        <div class="js-review-modal-backdrop fixed inset-0 z-10 hidden bg-black bg-opacity-75"></div>
+        <div
+          class="js-review-modal fixed left-1/2 top-5 z-20 hidden max-h-[calc(100vh-2.5rem)] w-11/12 -translate-x-1/2 overflow-y-auto rounded-xl bg-white py-16 shadow-modal lg:w-3/5"
+          tabindex="-1"
+          aria-modal="true"
+        >
+          {%- render './snippets/close-modal.svg.liquid',
+            classes: 'js-review-modal-close absolute right-2.5 top-2.5 cursor-pointer'
+          -%}
+          <h4 class="mb-4 px-2.5 text-2xl lg:px-6">{{- review.job_title -}}</h4>
+          <p class="px-2.5 lg:px-6">{{- review.review -}}</p>
+        </div>
       </article>
     {%- endfor %}
   </div>

--- a/snippets/close-modal.svg.liquid
+++ b/snippets/close-modal.svg.liquid
@@ -1,5 +1,5 @@
 <svg
-  class="js-portfolio-modal-close absolute right-2.5 top-2.5 cursor-pointer"
+  class="{{ classes | default: 'js-portfolio-modal-close absolute right-2.5 top-2.5 cursor-pointer' }}"
   width="24"
   height="24"
   viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- show truncated testimonials with a "Read full review" button
- open a dedicated modal for each review using reusable markup
- handle review modal open/close and focus trapping in script.js

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895d8c0d65883249fdd25ee36f6a014